### PR TITLE
feat(servicios): agregar página ServicioDetalle y componentes reutilizables

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import AppLayout from './layout/AppLayout';
 import Home from './pages/Home';
 import Servicios from './pages/Servicios';
@@ -13,7 +13,9 @@ import CompraExitosa from './pages/CompraExitosa';
 import CompraError from './pages/CompraError';
 import Checkout from './pages/Checkout';
 import RequireAuth from './components/RequireAuth';
+import ServicioDetalle from './pages/ServicioDetalle';
 
+//falta proteger las rutas 
 
 
 export default function App() {
@@ -22,6 +24,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/servicios" element={<Servicios />} />
+        <Route path="/servicio/:sku" element={<ServicioDetalle />} />
         <Route path="/blogs" element={<Blogs />} />
         <Route path="/nosotros" element={<Nosotros />} />
         <Route path="/contacto" element={<Contacto />} />

--- a/src/components/Breadcrumb.jsx
+++ b/src/components/Breadcrumb.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { CAT_LABEL} from '../utils/formatters';
+
+
+// ─── Migas compactas: Home / Servicios / Categoría ───────────────────────
+export default function ServiceBreadcrumb({ categoria }) {
+  const label = CAT_LABEL[categoria] || categoria || "Servicios";
+  return (
+    <nav className="small mb-2" aria-label="breadcrumb">
+      <ol className="breadcrumb mb-0">
+        <li className="breadcrumb-item"><Link to="/">Home</Link></li>
+        <li className="breadcrumb-item"><Link to="/servicios">Servicios</Link></li>
+        <li className="breadcrumb-item active" aria-current="page">{label}</li>
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/CardServicio.jsx
+++ b/src/components/CardServicio.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useCart } from '../context/CartContext';
+import { showToast } from '../utils/toast';
 
 export default function CardServicio({ servicio, ...rest}) {
   const s = servicio ?? rest;
@@ -22,6 +23,7 @@ export default function CardServicio({ servicio, ...rest}) {
 
   const handleAdd = () => {
       addItem({ sku, nombre, precio, img: imgSrc, categoria, duracionMin, qty: 1 });
+      showToast(`Agregado: ${servicio.nombre}`, 'success');
   };
 
   return (
@@ -36,7 +38,7 @@ export default function CardServicio({ servicio, ...rest}) {
           <h3 className="h6">{nombre} {duracionMin ? <i className="bi bi-clock"></i> : null}</h3>
           <p className="text-muted mb-2">{precioCLP}</p>
           <div className="d-grid gap-2 mt-auto">
-            <Link to={`/producto/${sku}`} className="btn btn-outline-success btn-sm">Ver detalle</Link>
+            <Link to={`/servicio/${sku}`} className="btn btn-outline-success btn-sm">Ver detalle</Link>
             <button type="button" className="btn btn-outline-success btn-sm">Agendar</button>
             <button type="button" className="btn btn-success btn-sm" onClick={handleAdd}>Agregar</button>
           </div>

--- a/src/components/Relacionados.jsx
+++ b/src/components/Relacionados.jsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { useCart } from '../context/CartContext';
+import { CAT_LABEL, CLP } from '../utils/formatters';
+import { showToast } from '../utils/toast';
+
+export default function RelatedServices({ all =[], actual }) {
+  const {addItem} = useCart();
+
+  const relacionados = (all || [])
+    .filter(x => x.categoria === actual?.categoria && x.sku !== actual?.sku)
+    .slice(0, 3);
+
+  if (!relacionados.length) return null;
+
+  const handleAdd = (r) => {
+    addItem({ sku: r.sku, nombre: r.nombre, precio: r.precio, qty: 1 });
+    showToast(`Agregado: ${r.nombre}`, "success");
+  };
+
+  return (
+    <section className="mt-5">
+      <h3 className="h5 mb-3">También te puede interesar</h3>
+      <div className="row g-3">
+        {relacionados.map(r => (
+          <div key={r.sku} className="col-12 col-md-6 col-lg-4">
+            <div className="card h-100 hover-card">
+              {!!r.img && (
+                <img
+                  src={r.img}
+                  alt={r.nombre}
+                  className="card-img-top"
+                  style={{ height: 200, objectFit: "cover" }}
+                />
+              )}
+              <div className="card-body d-flex flex-column">
+                <span className="badge rounded-pill bg-brand-soft text-brand mb-2">
+                  {CAT_LABEL[r.categoria] || r.categoria}
+                </span>
+
+                <h4 className="h6 mb-1">{r.nombre}</h4>
+                <p className="text-muted mb-3">{CLP.format(r.precio)}</p>
+
+                <div className="mt-auto d-grid gap-2">
+                  <Link
+                    to={`/servicio/${encodeURIComponent(r.sku)}`}
+                    className="btn btn-outline-success btn-sm"
+                  >
+                    Ver detalle
+                  </Link>
+                  <button
+                    type="button"
+                    className="btn btn-success btn-sm"
+                    onClick={() => handleAdd(r)}
+                  >
+                    Agregar
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ServiceMetaBar.jsx
+++ b/src/components/ServiceMetaBar.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { CAT_LABEL} from '../utils/formatters';
+
+
+export default function ServiceMetaBar({ duracionMin, categoria }) {
+  const label = CAT_LABEL[categoria] || categoria;
+  return (
+    <div className="text-secondary small d-flex align-items-center gap-3">
+      {duracionMin ? (
+        <span><i className="bi bi-clock me-1" />{duracionMin} min</span>
+      ) : null}
+      {label ? (
+        <span className="d-inline-flex align-items-center">
+          <i className="bi bi-tag me-1" />
+          {label}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ServiceSummaryCard.jsx
+++ b/src/components/ServiceSummaryCard.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { CAT_LABEL, CLP } from '../utils/formatters';
+import { showToast } from '../utils/toast';
+
+
+// ─── Tarjeta de resumen y acciones ───────────────────────────────────────
+export default function ServiceSummaryCard({ s, onAdd, onAgenda }) {
+  const handleAdd = () => {
+    onAdd?.(s);                     
+    showToast(`Agregado: ${s.nombre}`, 'success');
+  };
+  const handleAgenda = () => {
+    // proximamente aqui va la logica de agendar
+    navigate("/carrito");
+  };
+
+  return (
+    <div className="card h-100">
+      <div className="card-body">
+        {/* Chip categoría */}
+        <span className="badge rounded-pill bg-brand-soft text-brand mb-2">
+          {CAT_LABEL[s.categoria] || s.categoria}
+        </span>
+
+        {/* Nombre SOLO aquí */}
+        <h2 className="h4 mb-2">{s.nombre}</h2>
+
+        {/* Precio */}
+        <div className="display-6 mb-3">{CLP.format(s.precio)}</div>
+
+        {/* Descripción */}
+        <p className="text-secondary">{s.descripcion || "Este servicio ofrece una experiencia de bienestar diseñada para relajar cuerpo y mente."}</p>
+
+        {/* Acciones */}
+        <div className="d-grid gap-2">
+          <button className="btn btn-success d-flex justify-content-center align-items-center gap-2" onClick={handleAdd}>
+            <i className="bi bi-cart3" /> Agregar
+          </button>
+          <button className="btn btn-outline-success d-flex justify-content-center align-items-center gap-2" onClick={handleAgenda}>
+            <i className="bi bi-calendar-check" /> Agendar
+          </button>
+          <Link to="/servicios" className="btn btn-light">
+            ← Volver a servicios
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/layout/AppLayout.jsx
+++ b/src/layout/AppLayout.jsx
@@ -11,6 +11,7 @@ export default function AppLayout({ children }) {
         <main className="container py-4 flex-grow-1">{children}</main>
         
       <Footer />
+      <div id="toastArea" className="toast-container position-fixed bottom-0 end-0 p-3" />
       </div>
     </CartProvider>
     

--- a/src/pages/ServicioDetalle.jsx
+++ b/src/pages/ServicioDetalle.jsx
@@ -1,1 +1,100 @@
-export default function ServicioDetalle() { return <h2>Servicio Detalle</h2>; }
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { getServicios } from "../data/api";
+import { useCart } from "../context/CartContext";
+import {SERVICIOS as LOCAL_SERV} from "../data/data";
+import ServiceBreadcrumb from "../components/Breadcrumb";
+import ServiceMetaBar from "../components/ServiceMetaBar";
+import ServiceSummaryCard from "../components/ServiceSummaryCard";
+import RelatedServices from "../components/relacionados";
+import { showToast } from "../utils/toast";
+
+export default function ServicioDetalle() {
+  const { sku } = useParams();
+  const navigate = useNavigate();
+  const { addItem } = useCart();
+
+  const [servicios, setServicios] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [s, setS] = useState(undefined);
+
+  useEffect(() => {
+    let mounted = true;
+    getServicios()
+      .then(data => {
+        if (!mounted) return;
+        const list = data?.servicios ?? [];
+        setServicios(list);
+        setS(list.find(x => String(x.sku) === String(sku)) || null);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        const list = LOCAL_SERV ?? [];
+        setServicios(list);
+        setS(list.find(x => String(x.sku) === String(sku)) || null);
+      })
+      .finally(() => setLoading(false));
+
+    return () => { mounted = false };
+  }, [sku]);
+
+  if (loading || s === undefined) {
+  return (
+    <div className="container py-5 text-center">
+      <div className="spinner-border text-success" role="status">
+        <span className="visually-hidden">Cargando...</span>
+      </div>
+      <p className="mt-3 text-muted">Cargando servicio...</p>
+    </div>
+  );
+}
+  if (!s) {
+  return (
+    <div className="container py-5 text-center">
+      <h5 className="text-danger">Servicio no encontrado.</h5>
+      <Link to="/servicios" className="btn btn-outline-success mt-3">
+        ← Volver a servicios
+      </Link>
+    </div>
+  );
+}
+
+  const handleAdd = (item) => {
+  addItem({ sku: item.sku, nombre: item.nombre, precio: item.precio, qty: 1 });
+
+};
+  const handleAgenda = () => {
+    // proximamente aqui va la logica de agendar
+    navigate("/carrito");
+  };
+
+  return (
+    <div className="container py-4">
+      <ServiceBreadcrumb categoria={s.categoria} />
+
+     
+      <h1 className="h3 mb-1">{s.nombre}</h1>
+      <ServiceMetaBar duracionMin={s.duracionMin} categoria={s.categoria} />
+
+      <div className="row g-4 align-items-start mt-2">
+        {/* Galería / imagen */}
+        <div className="col-12 col-lg-7">
+          <div className="card border-0 shadow-sm">
+            {s.img ? (
+              <img src={s.img} alt={s.nombre} className="w-100 rounded" style={{ objectFit: "cover", maxHeight: "460px" }} />
+            ) : (
+              <div className="ratio ratio-16x9 bg-light rounded" />
+            )}
+          </div>
+        </div>
+
+        {/* Resumen y CTA (contiene nombre, precio y desc – no repetimos fuera) */}
+        <div className="col-12 col-lg-5">
+          <ServiceSummaryCard s={s} onAdd={handleAdd} onAgenda={handleAgenda} />
+        </div>
+      </div>
+
+      <RelatedServices all={servicios} actual={s}/>
+    </div>
+  );
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -148,6 +148,22 @@ main {
   --bs-btn-disabled-bg: transparent;
   --bs-btn-disabled-border-color: var(--brand);
 }
+
+/* Chip de categoría  */
+.bg-brand-soft {
+  background: var(--mint-1) !important;
+}
+.text-brand { color: var(--brand) !important; }
+
+/* Card hover  */
+.hover-card {
+  transition: transform .15s ease, box-shadow .15s ease;
+}
+.hover-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 .5rem 1rem rgba(0,0,0,.08);
+}
+
 #cartCount { display: inline-block !important; }
 
 /* Ajuste fino del badge del carrito */

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export const CAT_LABEL = {
+  masajes: "Masajes",
+  corporales: "Tratamientos corporales",
+  circuitos: "Circuitos de agua y sauna",
+  individuales: "Programas individuales",
+  parejas: "Programas en pareja",
+  "escapada-amigas": "Escapada de amigas",
+};
+
+export const CLP = new Intl.NumberFormat("es-CL", {
+  style: "currency",
+  currency: "CLP",
+  maximumFractionDigits: 0,
+});

--- a/src/utils/toast.js
+++ b/src/utils/toast.js
@@ -1,0 +1,24 @@
+import Toast from 'bootstrap/js/dist/toast';
+
+export function showToast(msg, variant = "success", delay = 1600) {
+  const area = document.getElementById("toastArea");
+  if (!area) return;
+
+  const el = document.createElement("div");
+  el.className = `toast align-items-center text-bg-${variant} border-0`;
+  el.setAttribute("role", "status");
+  el.setAttribute("aria-live", "polite");
+  el.setAttribute("aria-atomic", "true");
+  el.innerHTML = `
+    <div class="d-flex">
+      <div class="toast-body">${msg}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Cerrar"></button>
+    </div>
+  `;
+  area.appendChild(el);
+
+
+  const toast = new Toast(el, { delay });
+  toast.show();
+  el.addEventListener("hidden.bs.toast", () => el.remove());
+}


### PR DESCRIPTION


- Se creó la vista `ServicioDetalle` con soporte de carga desde API o datos locales.
- Nuevos componentes reutilizables:
  - `Breadcrumb` → navegación contextual del servicio.
  - `ServiceMetaBar` → muestra duración y categoría del servicio.
  - `ServiceSummaryCard` → muestra precio, descripción y botones de acción.
  - `Relacionados` → muestra servicios relacionados con botón de agregar al carrito.
- Se agregaron utilidades globales:
  - `utils/format.js` → contiene `CAT_LABEL` y formateador de moneda CLP.
  - `utils/toast.js` → función `showToast` global con soporte Bootstrap.
- Se actualizó `AppLayout` con contenedor global de toasts.
- Se actualizaron rutas en `App.jsx` incluyendo `/servicio/:sku`.
- Se actualizó `CardServicio` para integrar `showToast` al botón Agregar.

- Ahora el toast se muestra correctamente en todas las páginas que tengan botones “Agregar”.